### PR TITLE
Add additional check to avoid out-of-bound

### DIFF
--- a/gamelogic/src/main/java/at/aau/se2/gamelogic/GameLogic.java
+++ b/gamelogic/src/main/java/at/aau/se2/gamelogic/GameLogic.java
@@ -924,7 +924,7 @@ public class GameLogic {
     int cardCountToMulligan = 3;
     if (gameField.getRoundNumber() == 0) cardCountToMulligan = 6;
 
-    for (int i = 0; i < cardCountToMulligan; i++) {
+    for (int i = 0; i < cardCountToMulligan && i < playingCards.size(); i++) {
       cardsToMulligan.add(playingCards.get(i));
     }
 


### PR DESCRIPTION
Add additional bound check to avoid out of bound exception (happens if the function gets called when the calling player has less than 3 cards in hand). 